### PR TITLE
upgrade rest-client to 2.0

### DIFF
--- a/xfrtuc.gemspec
+++ b/xfrtuc.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = Xfrtuc::VERSION
   gem.license       = "MIT"
 
-  gem.add_runtime_dependency 'rest-client', '~> 1.6'
+  gem.add_runtime_dependency 'rest-client', '~> 2.0'
 
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'sham_rack', '~> 1.3'


### PR DESCRIPTION
```
ᐅ bundle install
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Using bundler 2.0.2
Using diff-lcs 1.3
Using unf_ext 0.0.7.6
Using unf 0.1.4
Using domain_name 0.5.20190701
Using http-accept 1.7.0
Using http-cookie 1.0.3
Using mime-types-data 3.2019.1009
Fetching mime-types 3.3.1 (was 2.99.3)
Installing mime-types 3.3.1 (was 2.99.3)
Using netrc 0.11.0
Using rack 2.1.2
Using rest-client 2.1.0 (was 1.8.0)
Using rspec-support 3.9.2
Using rspec-core 3.9.1
Using rspec-expectations 3.9.0
Using rspec-mocks 3.9.1
Using rspec 3.9.0
Using sham_rack 1.4.1
Using xfrtuc 0.0.11 from source at `.`
Bundle complete! 3 Gemfile dependencies, 19 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
ᐅ be rspec spec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 24677
.......................

Finished in 0.22101 seconds (files took 0.3462 seconds to load)
23 examples, 0 failures

Randomized with seed 24677
```