### PR TITLE
CircleCI and deprecation warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+orbs:
+  ruby: circleci/ruby@0.1.2 
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.6.3-stretch-node
+    executor: ruby/default
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/bundle-install
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.3-stretch-node
+      - image: circleci/ruby:2.7.2-stretch-node
     executor: ruby/default
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,4 @@ jobs:
           name: Which bundler?
           command: bundle -v
       - ruby/bundle-install
+      - run: bundle exec rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.7.2-stretch-node
+      - image: circleci/ruby:2.7.2
     executor: ruby/default
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@0.1.2 
+  ruby: circleci/ruby@0.1.2
 
 jobs:
   build:
@@ -13,4 +13,3 @@ jobs:
           name: Which bundler?
           command: bundle -v
       - ruby/bundle-install
-

--- a/lib/xfrtuc.rb
+++ b/lib/xfrtuc.rb
@@ -29,7 +29,7 @@ module Xfrtuc
         @group_client ||= Xfrtuc::Group.new(self)
       else
         self.class.new(@username, @password,
-                       @base_url + "/groups/#{URI.encode(name)}")
+                       @base_url + "/groups/#{CGI.escape(name)}")
       end
     end
 
@@ -64,7 +64,7 @@ module Xfrtuc
     def initialize(client); super; end
 
     def info(name)
-      client.get("/groups/#{URI.encode(name)}")
+      client.get("/groups/#{CGI.escape(name)}")
     end
 
     def list
@@ -76,7 +76,7 @@ module Xfrtuc
     end
 
     def delete(name)
-      client.delete("/groups/#{URI.encode(name)}")
+      client.delete("/groups/#{CGI.escape(name)}")
     end
   end
 
@@ -123,15 +123,15 @@ module Xfrtuc
     end
 
     def delete(id)
-      client.delete("/transfers/#{URI.encode(id)}")
+      client.delete("/transfers/#{CGI.escape(id)}")
     end
 
     def cancel(id)
-      client.post("/transfers/#{URI.encode(id)}/actions/cancel")
+      client.post("/transfers/#{CGI.escape(id)}/actions/cancel")
     end
 
     def public_url(id, opts={})
-      client.post("/transfers/#{URI.encode(id)}/actions/public-url", opts)
+      client.post("/transfers/#{CGI.escape(id)}/actions/public-url", opts)
     end
   end
 
@@ -168,11 +168,11 @@ module Xfrtuc
       sched_opts[:retain_weeks] = retain_weeks unless retain_weeks.nil?
       sched_opts[:retain_months] = retain_months unless retain_months.nil?
 
-      client.put("/schedules/#{URI.encode(name)}", sched_opts)
+      client.put("/schedules/#{CGI.escape(name)}", sched_opts)
     end
 
     def delete(id)
-      client.delete("/schedules/#{URI.encode(id)}")
+      client.delete("/schedules/#{CGI.escape(id)}")
     end
   end
 end

--- a/spec/xfrtuc_spec.rb
+++ b/spec/xfrtuc_spec.rb
@@ -368,7 +368,7 @@ module Xfrtuc
           group_client = client.group(group_name)
           expect(group_client).to be_instance_of(Client)
           expect(group_client.base_url).to eq(client.base_url +
-                                              "/groups/#{URI.encode(group_name)}")
+                                              "/groups/#{CGI.escape(group_name)}")
         end
       end
 


### PR DESCRIPTION
- Adding CircleCI
- Fixing deprecation warnings

there is a subtle change in how it works but i don't believe that we encode white space

URI.escape("hi you")
=> "hi%20you"

CGI.escape("hi you")
=> "hi+you"